### PR TITLE
Fix missing explanation output

### DIFF
--- a/nsfw_grok_to_ponyxl.py
+++ b/nsfw_grok_to_ponyxl.py
@@ -15,15 +15,20 @@ class NSFWGrokToPonyXL:
             }
         }
 
-    RETURN_TYPES = ("STRING", "STRING", "STRING")
-    RETURN_NAMES = ("ponyxl_prompt", "wan_prompt", "negative_prompt")
+    RETURN_TYPES = ("STRING", "STRING", "STRING", "STRING")
+    RETURN_NAMES = ("ponyxl_prompt", "wan_prompt", "negative_prompt", "explanation")
     FUNCTION = "generate_prompts"
     CATEGORY = "GrokPrompting"
     OUTPUT_NODE = True
 
     def generate_prompts(self, description, api_key, motion_type):
         if not api_key:
-            return (description, "", "blurry, low_quality, bad_anatomy, oversaturated")
+            return (
+                description,
+                "",
+                "blurry, low_quality, bad_anatomy, oversaturated",
+                "",
+            )
         try:
             headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
             data = {
@@ -47,7 +52,10 @@ class NSFWGrokToPonyXL:
             result_dict = json.loads(result)
             ponyxl_prompt = result_dict.get("ponyxl_prompt", description)
             wan_prompt = result_dict.get("wan_prompt", "")
-            negative_prompt = result_dict.get("negative_prompt", "blurry, low_quality, bad_anatomy, oversaturated")
-            return (ponyxl_prompt, wan_prompt, negative_prompt)
+            negative_prompt = result_dict.get(
+                "negative_prompt", "blurry, low_quality, bad_anatomy, oversaturated"
+            )
+            explanation = result_dict.get("explanation", "")
+            return (ponyxl_prompt, wan_prompt, negative_prompt, explanation)
         except Exception as e:
-            return (description, "", "blurry, low_quality, bad_anatomy, oversaturated")
+            return (description, "", "blurry, low_quality, bad_anatomy, oversaturated", "")


### PR DESCRIPTION
## Summary
- include an additional `explanation` string in `NSFWGrokToPonyXL`
- update return values to handle four outputs

## Testing
- `python -m py_compile grok_prompting/nsfw_grok_to_ponyxl.py`
- `python -m py_compile grok_prompting/nsfw_grok_describer.py`


------
https://chatgpt.com/codex/tasks/task_e_684267eb20d88322b06767a99810731b