### PR TITLE
Fix explanation doc for nsfw prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # grok_prompting
+
+This package provides ComfyUI nodes that use X.AI's Grok models to
+generate detailed prompts for NSFW content.
+
+## NSFWGrokToPonyXL
+The `generate_prompts` method returns four strings:
+1. `ponyxl_prompt` - tag-based prompt for PonyXL.
+2. `wan_prompt` - short Wan video description.
+3. `negative_prompt` - tags to avoid.
+4. `explanation` - summary of how the prompt was optimized.

--- a/nsfw_grok_to_ponyxl.py
+++ b/nsfw_grok_to_ponyxl.py
@@ -2,6 +2,13 @@ import requests
 import json
 
 class NSFWGrokToPonyXL:
+    """Generate PonyXL and Wan prompts using Grok.
+
+    The node requests the Grok API to produce a detailed PonyXL prompt,
+    a short Wan video prompt, a negative prompt, and a brief explanation
+    describing the optimization steps.
+    """
+
     def __init__(self):
         pass
 
@@ -22,6 +29,20 @@ class NSFWGrokToPonyXL:
     OUTPUT_NODE = True
 
     def generate_prompts(self, description, api_key, motion_type):
+        """Return prompts and a brief explanation from Grok.
+
+        Args:
+            description (str): A short description of the desired scene.
+            api_key (str): X.AI API key for authentication.
+            motion_type (str): Visual motion to include in the Wan prompt.
+
+        Returns:
+            tuple[str, str, str, str]:
+                - ponyxl_prompt: Detailed tag-based prompt for PonyXL.
+                - wan_prompt: Short sentence for the Wan video model.
+                - negative_prompt: Tags to discourage in generation.
+                - explanation: Summary of prompt optimization steps.
+        """
         if not api_key:
             return (
                 description,


### PR DESCRIPTION
## Summary
- document explanation output for NSFWGrokToPonyXL
- add class and function docstrings
- update README with details about return values

## Testing
- `python3 -m py_compile nsfw_grok_to_ponyxl.py nsfw_grok_describer.py __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68426923c014832287625f112fe0c7ea